### PR TITLE
Fix WebMock LLM tests to handle empty file upload errors correctly

### DIFF
--- a/spec/requests/prompt_engine/playground_spec.rb
+++ b/spec/requests/prompt_engine/playground_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "webmock/rspec"
 
 module PromptEngine
   RSpec.describe "Playground", type: :request do


### PR DESCRIPTION
## Summary
- Fixes test failures in LLM evaluation edge cases by properly mocking OpenAiEvalsClient methods
- Replaces WebMock error expectation with APIError for empty file upload scenario
- Removes unnecessary WebMock require from playground specs

## Changes

### Test Fixes
- In `eval_edge_cases_spec.rb`:
  - Mock `create_eval` to return a successful eval ID
  - Mock `upload_file` to raise `PromptEngine::OpenAiEvalsClient::APIError` with message "File contains no data" when uploading an empty file
  - Update expectation to check for `APIError` instead of `WebMock::NetConnectNotAllowedError`
  - Verify that eval run status is set to `failed` with the correct error message after upload failure
- In `playground_spec.rb`:
  - Remove `require "webmock/rspec"` as it is not needed

## Test plan
- Run integration tests to confirm that the empty file upload error is properly handled and reflected in eval run status
- Verify playground request specs run without WebMock dependency

This improves test reliability and correctness by accurately simulating client API errors instead of relying on WebMock network error stubs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d6532b74-5e33-400a-b82c-0a7fad39e882