### PR TITLE
feat: add multi-modal file support to playground executor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ bin/rails prompt_engine:install:migrations  # Install engine migrations in host 
 - Handles AI provider communication (Anthropic, OpenAI)
 - Manages API keys from Rails credentials
 - Formats requests and parses responses
+- Supports PDF file attachments for document-based prompts
 
 ### Testing Philosophy
 
@@ -172,6 +173,7 @@ Read `.ai/RSPEC-TESTS.md` before writing tests. Key principles:
 - Supports multiple models (GPT-4, Claude, etc.)
 - Real-time execution with streaming responses
 - Token counting and cost estimation
+- PDF file support for document analysis and processing
 
 ### Engine Integration
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ test, and optimize their AI prompts without deploying code changes.
 - **A/B Testing**: Test different prompt variations with built-in evaluation tools
 - **No Deploy Required**: Update prompts through the admin UI without code changes
 - **LLM Agnostic**: Works with OpenAI, Anthropic, and other providers
+- **Multi-Modal Support**: Upload and process PDF documents and images in prompts
 - **Type Safety**: Automatic parameter detection and validation
 - **Team Collaboration**: Centralized prompt management for your entire team
 - **Production Ready**: Battle-tested with secure API key storage
@@ -22,6 +23,7 @@ test, and optimize their AI prompts without deploying code changes.
 - 🎯 **Smart Prompt Management**: Create and organize prompts with slug-based identification
 - 📝 **Version Control**: Automatic versioning with one-click rollback
 - 🔍 **Variable Detection**: Auto-detects `{{variables}}` and creates typed parameters
+- 📎 **File Support**: Upload PDFs and images (JPG, PNG, GIF, WebP) as prompt parameters
 - 🧪 **Playground**: Test prompts with real AI providers before deploying
 - 📊 **Evaluation Suite**: Create test cases and measure prompt performance
 - 🔐 **Secure**: Encrypted API key storage using Rails encryption
@@ -266,6 +268,12 @@ rendered = PromptEngine.render("customer-support",
   issue: "Can't login to my account"
 )
 
+# Render a prompt with file uploads
+rendered = PromptEngine.render("document-analysis",
+  analysis_request: "Summarize the key points",
+  document: uploaded_file  # File object (PDF, JPG, PNG, GIF, WebP)
+)
+
 # Access rendered content
 rendered.content         # => "Hello John, I understand you're having trouble..."
 rendered.system_message  # => "You are a helpful customer support agent..."
@@ -298,9 +306,11 @@ rendered = PromptEngine.render("onboarding-email",
 
 1. **Create Prompts**: Use the admin UI to create prompts with `{{variables}}`
 2. **Auto-Detection**: PromptEngine automatically detects variables and creates parameters
-3. **Version Control**: Every save creates a new version automatically
-4. **Test & Deploy**: Test in the playground, then use in your application
-5. **Monitor**: Track usage and performance through the dashboard
+3. **Configure Parameters**: Set parameter types including text, number, boolean, and file
+4. **File Upload**: Upload PDFs and images directly in the playground for multi-modal prompts
+5. **Version Control**: Every save creates a new version automatically
+6. **Test & Deploy**: Test in the playground, then use in your application
+7. **Monitor**: Track usage and performance through the dashboard
 
 ## API Documentation
 
@@ -312,11 +322,17 @@ Renders a prompt template with the given variables.
 
 - `slug` (String): The unique identifier for the prompt
 - `**options` (Hash): Variables and optional overrides
-  - Variables: Any key-value pairs matching prompt variables
+  - Variables: Any key-value pairs matching prompt variables (including file uploads)
   - `model`: Override the default model
   - `temperature`: Override the default temperature
   - `max_tokens`: Override the default max tokens
   - `version`: Load a specific version number
+
+**File Parameters:**
+- Supported file types: PDF, JPG, PNG, GIF, WebP
+- Pass File objects or uploaded files as parameter values
+- Files are automatically processed and included in the LLM request
+- **PDF Support**: PDFs are currently only supported on Claude 3+ and Gemini models ([see RubyLLM documentation](https://rubyllm.com/guides/chat#working-with-pdfs))
 
 **Returns:** `PromptEngine::RenderedPrompt` instance
 

--- a/app/models/prompt_engine/parameter.rb
+++ b/app/models/prompt_engine/parameter.rb
@@ -3,7 +3,7 @@ module PromptEngine
     self.table_name = "prompt_engine_parameters"
 
     # Parameter types that can be used
-    TYPES = %w[string integer decimal boolean datetime date array json].freeze
+    TYPES = %w[string integer decimal boolean datetime date array json file].freeze
 
     belongs_to :prompt, class_name: "PromptEngine::Prompt"
 

--- a/app/views/prompt_engine/playground/show.html.erb
+++ b/app/views/prompt_engine/playground/show.html.erb
@@ -10,7 +10,7 @@
     <h3 class="card__title">Playground Settings</h3>
   </div>
   <div class="card__body">
-    <%= form_with url: playground_prompt_path(@prompt), method: :post, local: true, html: { class: "form" } do |form| %>
+    <%= form_with url: playground_prompt_path(@prompt), method: :post, local: true, html: { class: "form", multipart: true } do |form| %>
       <div class="form__group">
         <%= form.label :provider, "AI Provider", class: "form__label form__label--required" %>
         <% 
@@ -78,12 +78,21 @@
         <div class="form__help mb-md">Fill in the values for each parameter:</div>
         
         <% @parameters.each do |parameter_name| %>
+          <% parameter = @prompt.parameters.find_by(name: parameter_name) %>
           <div class="form__group">
             <%= form.label "parameters[#{parameter_name}]", parameter_name.humanize.titleize, class: "form__label" %>
-            <%= form.text_area "parameters[#{parameter_name}]", 
-                class: "form__textarea",
-                rows: 3,
-                placeholder: "Enter value for #{parameter_name}" %>
+            <% if parameter&.parameter_type == 'file' %>
+              <%= form.file_field "files[]", 
+                  class: "form__input",
+                  accept: ".pdf,.jpg,.jpeg,.png,.gif,.webp",
+                  multiple: false %>
+              <div class="form__help">Upload a file (PDF, JPG, PNG, GIF, WebP)</div>
+            <% else %>
+              <%= form.text_area "parameters[#{parameter_name}]", 
+                  class: "form__textarea",
+                  rows: 3,
+                  placeholder: "Enter value for #{parameter_name}" %>
+            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/prompt_engine/prompts/_form.html.erb
+++ b/app/views/prompt_engine/prompts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: prompt, local: true, html: { class: "form" }) do |form| %>
+<%= form_with(model: prompt, local: true, html: { class: "form", multipart: true }) do |form| %>
   <% if prompt.errors.any? %>
     <div class="form__errors">
       <h3 class="text-danger">Please fix the following errors:</h3>
@@ -210,6 +210,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <option value="boolean" ${existingData?.parameter_type === 'boolean' ? 'selected' : ''}>Boolean</option>
           <option value="array" ${existingData?.parameter_type === 'array' ? 'selected' : ''}>Array</option>
           <option value="object" ${existingData?.parameter_type === 'object' ? 'selected' : ''}>Object</option>
+          <option value="file" ${existingData?.parameter_type === 'file' ? 'selected' : ''}>File</option>
         </select>
       </div>
       


### PR DESCRIPTION
- Add support for PDF and image files (PDF, JPG, PNG, GIF, WebP) in playground
- Update PlaygroundExecutor to handle file uploads through parameters hash
- Add file type detection and validation for uploaded files
- Add 'file' parameter type support for prompt parameters
- Improve API key validation and error handling
- Updated README to include information about files