### PR TITLE
Fix duplicate migrations by skipping dummy app migration paths

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,60 @@
+# PromptEngine Migration Guide
+
+## Overview
+
+PromptEngine handles migrations differently for development (dummy app) and production (host app) environments to avoid duplicate migration issues.
+
+## Development Setup (Dummy App)
+
+When developing the engine or running tests:
+
+```bash
+bundle exec rake setup
+```
+
+This command:
+1. Clears existing migrations and databases
+2. Installs engine migrations into the dummy app using `rails prompt_engine:install:migrations`
+3. Creates and migrates both development and test databases
+
+The engine's initializer **skips** appending migration paths for the dummy app to prevent duplicates.
+
+## Production Setup (Host Application)
+
+When installing PromptEngine in a Rails application:
+
+### Option 1: Copy Migrations (Recommended)
+
+```bash
+bundle exec rails prompt_engine:install:migrations
+bundle exec rails db:migrate
+```
+
+This copies migrations to your app with timestamps and `.prompt_engine.rb` suffix.
+
+### Option 2: Runtime Loading
+
+If you prefer not to copy migrations, the engine will automatically load them at runtime.
+This happens through the engine's initializer for non-dummy applications.
+
+## Troubleshooting Duplicate Migrations
+
+If you encounter duplicate migration errors:
+
+1. **Check for copied migrations**: Look in your app's `db/migrate` folder for `.prompt_engine.rb` files
+2. **Remove duplicates**: If you have both copied migrations and runtime loading, remove the copied files
+3. **Consistent approach**: Choose either copying OR runtime loading, not both
+
+## Technical Details
+
+The engine detects the dummy app environment and skips the migration path appending initializer to prevent Rails from seeing migrations twice. This is implemented in `lib/prompt_engine/engine.rb`:
+
+```ruby
+initializer :append_migrations do |app|
+  unless app.root.to_s.match?(root.to_s) || app.root.to_s.include?('spec/dummy')
+    # Only append migration paths for real host apps, not the dummy app
+  end
+end
+```
+
+This ensures clean migration handling in all environments.

--- a/lib/prompt_engine/engine.rb
+++ b/lib/prompt_engine/engine.rb
@@ -14,8 +14,9 @@ module PromptEngine
 
     # Ensure engine's migrations are available to the host app
     # This is the standard Rails engine pattern
+    # Skip this for the dummy app to avoid duplicate migrations
     initializer :append_migrations do |app|
-      unless app.root.to_s.match?(root.to_s)
+      unless app.root.to_s.match?(root.to_s) || app.root.to_s.include?('spec/dummy')
         config.paths["db/migrate"].expanded.each do |expanded_path|
           app.config.paths["db/migrate"] << expanded_path
         end


### PR DESCRIPTION
## Summary
- Prevents duplicate migrations by skipping migration path appending for the dummy app environment
- Adds detailed migration guide documentation to clarify development and production migration handling

## Changes

### Core Fix
- Updated `lib/prompt_engine/engine.rb` initializer to exclude dummy app (`spec/dummy`) from appending migration paths
  - Ensures migrations are only appended for real host applications

### Documentation
- Added `docs/MIGRATIONS.md` with comprehensive migration guide:
  - Explains different migration handling for development (dummy app) vs production (host app)
  - Provides setup instructions for both environments
  - Details troubleshooting steps for duplicate migration errors
  - Includes technical explanation of the migration path skipping logic

## Test plan
- Verified no duplicate migration errors occur when running migrations in dummy app environment
- Confirmed migrations are appended correctly in host app environment
- Reviewed documentation for clarity and completeness

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1851eb34-e762-4f3c-be07-90ec8d441337