### PR TITLE
Add configuration support for model selection in PromptEngine

### DIFF
--- a/app/views/prompt_engine/prompts/_form.html.erb
+++ b/app/views/prompt_engine/prompts/_form.html.erb
@@ -67,14 +67,7 @@
     <div class="form__group">
       <%= form.label :model, "AI Model", class: "form__label" %>
       <%= form.select :model, 
-          options_for_select([
-            ["GPT-4", "gpt-4"],
-            ["GPT-4 Turbo", "gpt-4-turbo-preview"],
-            ["GPT-3.5 Turbo", "gpt-3.5-turbo"],
-            ["Claude 3 Opus", "claude-3-opus"],
-            ["Claude 3 Sonnet", "claude-3-sonnet"],
-            ["Claude 3 Haiku", "claude-3-haiku"]
-          ], prompt.model),
+          options_for_select(PromptEngine.configuration.options_for_model_select, prompt.model),
           { include_blank: "Select a model" },
           class: "form__select" %>
     </div>

--- a/lib/prompt_engine.rb
+++ b/lib/prompt_engine.rb
@@ -58,5 +58,51 @@ module PromptEngine
     def [](slug)
       find(slug)
     end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    # Configures the PromptEngine by yielding the current configuration object.
+    # If no configuration exists, a new Configuration instance is created.
+    #
+    # @yieldparam [Configuration] configuration The configuration object to be modified.
+    # @return [void]
+    def configure
+      self.configuration ||= Configuration.new
+      yield(configuration)
+    end
+
+    # Configuration class manages model selection options for the prompt engine.
+    #
+    # Attributes:
+    #   options_for_model_select [Array<Array<String>>]: An array of pairs, where each pair contains
+    #     the display name and the identifier for a supported AI model.
+    #
+    # Examples:
+    #   PromptEngine.configure do |config|
+    #     config.options_for_model_select << ["New Model", "new-model-id"]
+    #   end
+    #
+    #   PromptEngine.configure do |config|
+    #     config.options_for_model_select = ["New Model", "new-model-id", ...]
+    #   end
+    #
+    # Usage:
+    #   Use this class to retrieve or modify the available model options for selection in the application.
+    class Configuration
+      attr_accessor :options_for_model_select
+
+      def initialize
+        @options_for_model_select = [
+          ["GPT-4", "gpt-4"],
+          ["GPT-4 Turbo", "gpt-4-turbo-preview"],
+          ["GPT-3.5 Turbo", "gpt-3.5-turbo"],
+          ["Claude 3 Opus", "claude-3-opus"],
+          ["Claude 3 Sonnet", "claude-3-sonnet"],
+          ["Claude 3 Haiku", "claude-3-haiku"]
+        ]
+      end
+    end
   end
 end

--- a/spec/lib/prompt_engine_configuration_spec.rb
+++ b/spec/lib/prompt_engine_configuration_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe PromptEngine do
+  describe "configure" do
+    it "yields the configuration object" do
+      PromptEngine.configure do |config|
+        config.options_for_model_select = [
+          ["Custom Model 1", "custom-model-1"]
+        ]
+      end
+
+      expect(
+        PromptEngine.configuration.options_for_model_select
+      ).to eq([["Custom Model 1", "custom-model-1"]])
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a configurable mechanism for managing AI model selection options in the PromptEngine, making it easier to customize which models are available for use in the application. The model selection options are now centralized in a configuration object, allowing for dynamic updates and improved maintainability. The most important changes are grouped below:

**Configuration and Customization Enhancements:**

* Added a `PromptEngine::Configuration` class with an `options_for_model_select` attribute to manage the list of selectable AI models. The configuration is initialized with the previously hardcoded list of models.
* Introduced `PromptEngine.configuration` and `PromptEngine.configure` methods to access and modify the configuration object, allowing external code to update model options as needed.

**View and Test Updates:**

* Updated the model select dropdown in the `_form.html.erb` partial to use `PromptEngine.configuration.options_for_model_select` instead of a hardcoded list, enabling dynamic model selection in the UI.
* Added a new RSpec test to verify that the configuration object can be updated and that changes to `options_for_model_select` are reflected in the application.

**Reasoning**
This change is so that we can customize the LLM Models available to test in the UI.

My use-case is to use `RubyLLM::Models.fetch_from_providers` to build a list of models I want to use.