### PR TITLE
Enhance variable detection to include system_message in prompt rendering

### DIFF
--- a/app/controllers/prompt_engine/playground_controller.rb
+++ b/app/controllers/prompt_engine/playground_controller.rb
@@ -3,7 +3,10 @@ module PromptEngine
     before_action :set_prompt
 
     def show
-      @parameters = ParameterParser.new(@prompt.content).extract_parameters.map { |p| p[:name] }
+      @parameters = ParameterParser.new(
+        @prompt.content + @prompt.system_message.to_s
+      ).extract_parameters.map { |p| p[:name] }
+
       @settings = Setting.instance
     end
 
@@ -24,8 +27,11 @@ module PromptEngine
         @provider = result[:provider]
 
         # Store the rendered prompt for display
-        parser = ParameterParser.new(@prompt.content)
-        @rendered_prompt = parser.replace_parameters(params[:parameters])
+        content_parser = ParameterParser.new(@prompt.content)
+        system_parser = ParameterParser.new(@prompt.system_message.to_s)
+
+        @rendered_prompt = content_parser.replace_parameters(params[:parameters])
+        @rendered_system_prompt = system_parser.replace_parameters(params[:parameters])
 
         # Save the playground run result
         @prompt.current_version.playground_run_results.create!(

--- a/app/models/prompt_engine/prompt.rb
+++ b/app/models/prompt_engine/prompt.rb
@@ -64,7 +64,7 @@ module PromptEngine
     # Parameter management methods
     def detect_variables
       # Don't cache the detector as content can change
-      PromptEngine::VariableDetector.new(content).variable_names
+      PromptEngine::VariableDetector.new(content + system_message.to_s).variable_names
     end
 
     def sync_parameters!
@@ -76,7 +76,7 @@ module PromptEngine
       if new_vars.any?
         # Get max position once, before the loop
         max_position = parameters.maximum(:position) || 0
-        detector = PromptEngine::VariableDetector.new(content)
+        detector = PromptEngine::VariableDetector.new(content + system_message.to_s)
 
         new_vars.each_with_index do |var_name, index|
           var_info = detector.extract_variables.find { |v| v[:name] == var_name }
@@ -101,7 +101,8 @@ module PromptEngine
     end
 
     def render_with_params(provided_params = {})
-      detector = PromptEngine::VariableDetector.new(content)
+      content_detector = PromptEngine::VariableDetector.new(content)
+      system_message_detector = PromptEngine::VariableDetector.new(system_message)
 
       # Validate all required parameters are provided
       validation = validate_parameters(provided_params)
@@ -125,8 +126,8 @@ module PromptEngine
       end
 
       {
-        content: detector.render(casted_params),
-        system_message: system_message,
+        content: content_detector.render(casted_params),
+        system_message: system_message_detector.render(casted_params),
         model: model,
         temperature: temperature,
         max_tokens: max_tokens,
@@ -183,12 +184,12 @@ module PromptEngine
       version = versions.find_by!(version_number: version_number)
 
       # Use version's content and settings
-      detector = PromptEngine::VariableDetector.new(version.content)
-      rendered_content = detector.render(variables)
+      content_detector = PromptEngine::VariableDetector.new(version.content)
+      system_message_detector = PromptEngine::VariableDetector.new(version.system_message)
 
       rendered_data = {
-        content: rendered_content,
-        system_message: version.system_message,
+        content: content_detector.render(variables),
+        system_message: system_message_detector.render(variables),
         model: version.model,
         temperature: version.temperature,
         max_tokens: version.max_tokens,

--- a/app/views/prompt_engine/prompts/_form.html.erb
+++ b/app/views/prompt_engine/prompts/_form.html.erb
@@ -12,7 +12,7 @@
 
   <div class="form__group">
     <%= form.label :name, class: "form__label form__label--required" %>
-    <%= form.text_field :name, class: "form__input", required: true, 
+    <%= form.text_field :name, class: "form__input", required: true,
         placeholder: "e.g., Customer Support Response",
         data: { action: "input->slug-generator#generateSlug" } %>
     <div class="form__help">A descriptive name for this prompt</div>
@@ -20,7 +20,7 @@
 
   <div class="form__group">
     <%= form.label :slug, class: "form__label form__label--required" %>
-    <%= form.text_field :slug, class: "form__input", required: true, 
+    <%= form.text_field :slug, class: "form__input", required: true,
         placeholder: "e.g., customer-support-response",
         data: { "slug-generator-target": "slugField" } %>
     <div class="form__help">URL-friendly identifier (lowercase letters, numbers, and hyphens only)</div>
@@ -35,7 +35,8 @@
   <div class="form__group">
     <%= form.label :system_message, "System Message", class: "form__label" %>
     <%= form.text_area :system_message, class: "form__textarea", rows: 4,
-        placeholder: "Instructions for the AI system (optional)" %>
+        placeholder: "Instructions for the AI system (optional)",
+        data: { action: "input->variable-detector-system#detectVariables" } %>
     <div class="form__help">Sets the behavior and context for the AI</div>
   </div>
 
@@ -50,11 +51,11 @@
   <div id="parameters-section" class="parameters-section" style="display: none;">
     <h3 class="form__section-title">Parameters</h3>
     <div class="form__help mb-md">Configure the parameters detected in your prompt:</div>
-    
+
     <div id="parameters-list" class="parameters-list">
       <!-- Parameters will be dynamically inserted here -->
     </div>
-    
+
     <%= form.fields_for :parameters do |parameter_form| %>
       <div class="parameter-fields" style="display: none;">
         <%= parameter_form.hidden_field :id %>
@@ -66,7 +67,7 @@
   <div class="form__inline">
     <div class="form__group">
       <%= form.label :model, "AI Model", class: "form__label" %>
-      <%= form.select :model, 
+      <%= form.select :model,
           options_for_select([
             ["GPT-4", "gpt-4"],
             ["GPT-4 Turbo", "gpt-4-turbo-preview"],
@@ -81,14 +82,14 @@
 
     <div class="form__group">
       <%= form.label :temperature, class: "form__label" %>
-      <%= form.number_field :temperature, class: "form__input", 
+      <%= form.number_field :temperature, class: "form__input",
           step: 0.1, min: 0, max: 2, placeholder: "0.7" %>
       <div class="form__help">0-2 (default: 0.7)</div>
     </div>
 
     <div class="form__group">
       <%= form.label :max_tokens, "Max Tokens", class: "form__label" %>
-      <%= form.number_field :max_tokens, class: "form__input", 
+      <%= form.number_field :max_tokens, class: "form__input",
           min: 1, placeholder: "500" %>
       <div class="form__help">Maximum response length</div>
     </div>
@@ -96,7 +97,7 @@
 
   <div class="form__group">
     <%= form.label :status, class: "form__label" %>
-    <%= form.select :status, 
+    <%= form.select :status,
         options_for_select([
           ["Draft", "draft"],
           ["Active", "active"],
@@ -108,7 +109,7 @@
 
   <div class="form__actions">
     <%= link_to "Cancel", prompts_path, class: "btn btn--secondary btn--medium" %>
-    <%= form.submit prompt.new_record? ? "Create Prompt" : "Update Prompt", 
+    <%= form.submit prompt.new_record? ? "Create Prompt" : "Update Prompt",
         class: "btn btn--primary btn--medium" %>
   </div>
 <% end %>
@@ -117,13 +118,14 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   const contentField = document.querySelector('[data-action="input->variable-detector#detectVariables"]');
+  const systemField = document.querySelector('[data-action="input->variable-detector-system#detectVariables"]');
   const parametersSection = document.getElementById('parameters-section');
   const parametersList = document.getElementById('parameters-list');
-  
+
   // Slug generation
   const nameField = document.querySelector('[data-action="input->slug-generator#generateSlug"]');
   const slugField = document.querySelector('[data-slug-generator-target="slugField"]');
-  
+
   if (nameField && slugField) {
     function generateSlug() {
       // Only auto-generate if slug is empty or if it's a new record
@@ -137,10 +139,10 @@ document.addEventListener('DOMContentLoaded', function() {
         slugField.value = slug;
       }
     }
-    
+
     nameField.addEventListener('input', generateSlug);
   }
-  
+
   // Store existing parameters data (for edit form)
   const existingParameters = <%= raw((prompt.persisted? ? prompt.parameters : []).map { |p| {
     name: p.name,
@@ -150,13 +152,14 @@ document.addEventListener('DOMContentLoaded', function() {
     default_value: p.default_value,
     id: p.id
   }}.to_json) %>;
-  
+
   function detectVariables() {
     const content = contentField.value;
+    const system = systemField.value;
     const variablePattern = /\{\{([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}\}/g;
-    const matches = [...content.matchAll(variablePattern)];
+    const matches = [...content.matchAll(variablePattern), ...system.matchAll(variablePattern)];
     const uniqueVariables = [...new Set(matches.map(match => match[1]))];
-    
+
     if (uniqueVariables.length > 0) {
       parametersSection.style.display = 'block';
       updateParametersDisplay(uniqueVariables);
@@ -164,17 +167,17 @@ document.addEventListener('DOMContentLoaded', function() {
       parametersSection.style.display = 'none';
     }
   }
-  
+
   function updateParametersDisplay(variables) {
     parametersList.innerHTML = '';
-    
+
     // Add fields for parameters that should be kept
     variables.forEach((variable, index) => {
       const existingParam = existingParameters.find(p => p.name === variable);
       const parameterItem = createParameterItem(variable, index, existingParam);
       parametersList.appendChild(parameterItem);
     });
-    
+
     // Add hidden fields to destroy parameters that are no longer in content
     let destroyIndex = variables.length;
     existingParameters.forEach(param => {
@@ -190,7 +193,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
-  
+
   function createParameterItem(variableName, index, existingData) {
     const div = document.createElement('div');
     div.className = 'parameter-item';
@@ -201,7 +204,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <input type="hidden" name="prompt[parameters_attributes][${index}][name]" value="${variableName}">
         ${existingData ? `<input type="hidden" name="prompt[parameters_attributes][${index}][id]" value="${existingData.id}">` : ''}
       </div>
-      
+
       <div class="parameter-field">
         <label>Type</label>
         <select name="prompt[parameters_attributes][${index}][parameter_type]" class="form__select form__select--small">
@@ -212,31 +215,31 @@ document.addEventListener('DOMContentLoaded', function() {
           <option value="object" ${existingData?.parameter_type === 'object' ? 'selected' : ''}>Object</option>
         </select>
       </div>
-      
+
       <div class="parameter-field">
         <label>Required</label>
         <div class="parameter-checkbox">
           <input type="hidden" name="prompt[parameters_attributes][${index}][required]" value="0">
-          <input type="checkbox" 
-                 name="prompt[parameters_attributes][${index}][required]" 
+          <input type="checkbox"
+                 name="prompt[parameters_attributes][${index}][required]"
                  value="1"
                  ${existingData?.required !== false ? 'checked' : ''}>
         </div>
       </div>
-      
+
       <div class="parameter-field">
         <label>Default Value</label>
-        <input type="text" 
-               name="prompt[parameters_attributes][${index}][default_value]" 
+        <input type="text"
+               name="prompt[parameters_attributes][${index}][default_value]"
                class="form__input form__input--small"
                placeholder="Optional"
                value="${existingData?.default_value || ''}">
       </div>
-      
+
       <div class="parameter-field">
         <label>Description</label>
-        <input type="text" 
-               name="prompt[parameters_attributes][${index}][description]" 
+        <input type="text"
+               name="prompt[parameters_attributes][${index}][description]"
                class="form__input form__input--small"
                placeholder="Optional"
                value="${existingData?.description || ''}">
@@ -244,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function() {
     `;
     return div;
   }
-  
+
   if (contentField) {
     contentField.addEventListener('input', detectVariables);
     // Detect variables on page load

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -507,6 +507,19 @@ RSpec.describe PromptEngine::Prompt, type: :model do
           expect(result[:error]).to include("item_count must be at most 150")
         end
       end
+
+      context "with parameters in the system_message" do
+        before do
+          prompt.update!(system_message: "Use this input schema {{input_schema}}")
+        end
+
+        it "renders variables in the system_message as well" do
+          result = prompt.render_with_params(name: "Alice", item_count: "10", input_schema: "object:schema")
+
+          expect(result[:content]).to eq("Hello Alice, you have 10 items")
+          expect(result[:system_message]).to eq("Use this input schema object:schema")
+        end
+      end
     end
 
     describe "#validate_parameters" do


### PR DESCRIPTION
This pull request updates how prompt variables are detected and rendered in the `PromptEngine::Prompt` model to ensure variables in both the `content` and `system_message` fields are properly handled. The main changes include extending variable detection to the `system_message`, updating rendering logic to interpolate variables in both fields, and adding tests to confirm this behavior.

**Variable detection and rendering improvements:**

* Variable detection now considers both `content` and `system_message` when identifying variables, ensuring all required parameters are recognized. [[1]](diffhunk://#diff-51195c635e4857385a5009d78ee71451ec4fa8e116d4891ac7df3b0191a5a979L67-R67) [[2]](diffhunk://#diff-51195c635e4857385a5009d78ee71451ec4fa8e116d4891ac7df3b0191a5a979L79-R79)
* Rendering logic in `render_with_params` and `render_version` now interpolates variables in both `content` and `system_message`, using separate detectors for each field. [[1]](diffhunk://#diff-51195c635e4857385a5009d78ee71451ec4fa8e116d4891ac7df3b0191a5a979L104-R105) [[2]](diffhunk://#diff-51195c635e4857385a5009d78ee71451ec4fa8e116d4891ac7df3b0191a5a979L128-R130) [[3]](diffhunk://#diff-51195c635e4857385a5009d78ee71451ec4fa8e116d4891ac7df3b0191a5a979L186-R192)

**Testing enhancements:**

* Added a test case to verify that variables in the `system_message` are rendered correctly, ensuring the new logic works as expected.

**Reasoning**

This allows us to pass variables in the `system_message` We are using this to pass schemas to the LLM.