### PR TITLE
Move SQLite to a dev dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       csv (~> 3.3)
       rails
       ruby_llm
-      sqlite3
 
 GEM
   remote: https://rubygems.org/

--- a/prompt_engine.gemspec
+++ b/prompt_engine.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails"
   spec.add_dependency "ruby_llm"
   spec.add_dependency "bcrypt"
-  spec.add_dependency "sqlite3"
   spec.add_dependency "csv", "~> 3.3"
 
   spec.add_development_dependency "rspec-rails", "~> 7.0"
@@ -32,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cuprite", "~> 0.15"
   spec.add_development_dependency "selenium-webdriver", "~> 4.27"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
This pull request updates the dependencies in the `prompt_engine.gemspec` file to move the `sqlite3` gem from a runtime dependency to a development dependency. This change ensures that `sqlite3` is only required for development and testing environments, not in production.

Dependency management:

* Removed `sqlite3` from the runtime dependencies to prevent it from being installed in production environments.
* Added `sqlite3` as a development dependency to ensure it is available for development and testing purposes.

**Reasoning**
People shouldn't have to install SQLite if they aren't using it in their app.